### PR TITLE
Add support for typed css tagged template literals

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://discord.gg/FcSNfg4"
   },
   "homepage": "https://www.fast.design/",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "engines": {
     "vscode": "^1.49.0"

--- a/syntaxes/fast-tagged-templates.tmLanguage.json
+++ b/syntaxes/fast-tagged-templates.tmLanguage.json
@@ -15,15 +15,29 @@
     ],
     "repository": {
         "css-tagged-template": {
-            "begin": "(?i)(?<!\\.)(css|((?:\\/\\*\\s*?)css(?:\\s*\\*\\/)))\\s*(`)",
+            "begin": "(?i)(?<!\\.)(css(<.*?>)?|((?:\\/\\*\\s*?)css(<.*?>)?(?:\\s*\\*\\/)))\\s*(`)",
             "beginCaptures": {
                 "1": {
                     "name": "entity.name.function.tagged-template.ts"
                 },
                 "2": {
-                    "name": "comment.block"
+                    "patterns": [
+                        {
+                            "include": "source.ts#type-parameters"
+                        }
+                    ]
                 },
                 "3": {
+                    "name": "comment.block"
+                },
+                "4": {
+                    "patterns": [
+                        {
+                            "include": "source.ts#type-parameters"
+                        }
+                    ]
+                },
+                "5": {
                     "name": "punctuation.definition.string.template.begin.ts"
                 }
             },

--- a/test/test.ts
+++ b/test/test.ts
@@ -159,6 +159,12 @@ css`
     }
 `;
 
+// typed css
+css<any>`
+    div #id .class[attribute] {
+    }
+`;
+
 /* Comment-style */
 
 /* html */ `<div></div>`;
@@ -171,6 +177,7 @@ css`
 /*css*/`.css {}`;
 /*              css          */               `.css {}`;
 /* css */ `.${exp} {}`;
+/* css<any> */`.css {}`;
 
 
 /* should not match */


### PR DESCRIPTION
fast-element has support for typed css templates but they're not supported by this extension. Screenshot of the update:
![image](https://github.com/user-attachments/assets/d9f2a58e-c4b7-4295-bac1-054bdefca0f2)
